### PR TITLE
feat: use tailwind-typography as article style

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 export default async function Home() {
     const text = (await getGistsFiles())['me.md']['content'];
     return (
-        <div className="post prose-p:my-2">
+        <div className="article prose-p:my-2">
             <Markdown>{text}</Markdown>
         </div>
     );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,7 @@ import Markdown from '@/components/markdown';
 import { getGistsFiles } from '@/utils/data';
 
 export const metadata: Metadata = {
-    title: '首页 - 幻非',
+    title: '幻非',
     alternates: {
         canonical: '/',
     },

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -13,7 +13,7 @@ export const metadata: Metadata = {
 export default async function Home() {
     const text = (await getGistsFiles())['me.md']['content'];
     return (
-        <div id="post">
+        <div className="post prose-p:my-2">
             <Markdown>{text}</Markdown>
         </div>
     );

--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -51,7 +51,7 @@ export default async function Post({ params }) {
         <>
             <article>
                 <Header post={post} />
-                <section className="post mt-5">
+                <section className="article mt-5">
                     <Markdown>{post.content}</Markdown>
                 </section>
             </article>

--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -51,7 +51,7 @@ export default async function Post({ params }) {
         <>
             <article>
                 <Header post={post} />
-                <section className={'post mt-5'}>
+                <section className="post mt-5">
                     <Markdown>{post.content}</Markdown>
                 </section>
             </article>

--- a/app/post/[id]/page.tsx
+++ b/app/post/[id]/page.tsx
@@ -51,7 +51,7 @@ export default async function Post({ params }) {
         <>
             <article>
                 <Header post={post} />
-                <section id="post">
+                <section className={'post mt-5'}>
                     <Markdown>{post.content}</Markdown>
                 </section>
             </article>

--- a/components/markdown/code.tsx
+++ b/components/markdown/code.tsx
@@ -15,7 +15,7 @@ export default function Code(props) {
         });
     };
     return (
-        <pre className="relative my-3 overflow-hidden rounded-xl bg-zinc-100 dark:bg-zinc-800" id="code">
+        <pre className="not-prose relative my-3 overflow-hidden rounded-xl bg-zinc-100 dark:bg-zinc-800" id="code">
             <button
                 className="absolute right-2 top-2 flex rounded-xl p-2 hover:bg-zinc-200 dark:hover:bg-zinc-800"
                 onClick={click}

--- a/components/markdown/index.tsx
+++ b/components/markdown/index.tsx
@@ -37,16 +37,15 @@ const linkHeadingsOptions: Options = {
     content: {
         type: 'element',
         tagName: 'span',
-        properties: { className: 'i-mingcute-link-line -scale-x-100', 'aria-hidden': 'true' },
+        properties: { className: 'i-mingcute-link-line -scale-x-100 h-full', 'aria-hidden': 'true' },
         children: [],
     },
     headingProperties: {
-        className: 'relative flex items-center group',
+        className: 'relative group',
     },
     properties: el => {
         return {
-            className:
-                '-translate-x-full not-prose absolute flex items-center pr-1.5 opacity-0 group-hover:opacity-100',
+            className: '-translate-x-full not-prose inset-y-0 absolute pr-1.5 opacity-0 group-hover:opacity-100',
             'aria-label': `Permalink: ${el.children[0]['value']}`,
             tabIndex: -1,
         };

--- a/components/markdown/index.tsx
+++ b/components/markdown/index.tsx
@@ -1,6 +1,6 @@
 import Link from 'next/link';
 import ReactMarkdown from 'react-markdown';
-import rehypeAutolinkHeadings from 'rehype-autolink-headings';
+import rehypeAutolinkHeadings, { type Options } from 'rehype-autolink-headings';
 import rehypeExternalLinks from 'rehype-external-links';
 import rehypeRaw from 'rehype-raw';
 import rehypeSlug from 'rehype-slug';
@@ -15,25 +15,7 @@ export default async function Markdown({ children }: { children: string }) {
             remarkPlugins={[remarkGfm]}
             rehypePlugins={[
                 rehypeSlug,
-                [
-                    rehypeAutolinkHeadings,
-                    {
-                        behavior: 'prepend',
-                        content: {
-                            type: 'element',
-                            tagName: 'span',
-                            properties: { className: 'i-mingcute-link-line -scale-x-100', 'aria-hidden': 'true' },
-                            children: [],
-                        },
-                        properties: (el: Element) => {
-                            return {
-                                className: 'anchor',
-                                'aria-label': `Permalink: ${el.children[0]['value']}`,
-                                tabIndex: -1,
-                            };
-                        },
-                    },
-                ],
+                [rehypeAutolinkHeadings, linkHeadingsOptions],
                 [rehypeExternalLinks, { target: '_blank', rel: ['noopener', 'external', 'nofollow', 'noreferrer'] }],
                 rehypeRaw,
             ]}
@@ -49,3 +31,24 @@ export default async function Markdown({ children }: { children: string }) {
         </ReactMarkdown>
     );
 }
+
+const linkHeadingsOptions: Options = {
+    behavior: 'prepend',
+    content: {
+        type: 'element',
+        tagName: 'span',
+        properties: { className: 'i-mingcute-link-line -scale-x-100', 'aria-hidden': 'true' },
+        children: [],
+    },
+    headingProperties: {
+        className: 'relative flex items-center group',
+    },
+    properties: el => {
+        return {
+            className:
+                '-translate-x-full not-prose absolute flex items-center pr-1.5 opacity-0 group-hover:opacity-100',
+            'aria-label': `Permalink: ${el.children[0]['value']}`,
+            tabIndex: -1,
+        };
+    },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
             "devDependencies": {
                 "@egoist/tailwindcss-icons": "^1.8.1",
                 "@iconify-json/mingcute": "^1.2.0",
+                "@tailwindcss/typography": "^0.5.15",
                 "@trivago/prettier-plugin-sort-imports": "^4.3.0",
                 "@types/react": "^18.3.10",
                 "@types/react-dom": "^18.3.0",
@@ -937,6 +938,36 @@
             "dependencies": {
                 "@swc/counter": "^0.1.3",
                 "tslib": "^2.4.0"
+            }
+        },
+        "node_modules/@tailwindcss/typography": {
+            "version": "0.5.15",
+            "resolved": "https://registry.npmmirror.com/@tailwindcss/typography/-/typography-0.5.15.tgz",
+            "integrity": "sha512-AqhlCXl+8grUz8uqExv5OTtgpjuVIwFTSXTrh8y9/pw6q2ek7fJ+Y8ZEVw7EB2DCcuCOtEjf9w3+J3rzts01uA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "lodash.castarray": "^4.4.0",
+                "lodash.isplainobject": "^4.0.6",
+                "lodash.merge": "^4.6.2",
+                "postcss-selector-parser": "6.0.10"
+            },
+            "peerDependencies": {
+                "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20"
+            }
+        },
+        "node_modules/@tailwindcss/typography/node_modules/postcss-selector-parser": {
+            "version": "6.0.10",
+            "resolved": "https://registry.npmmirror.com/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+            "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "cssesc": "^3.0.0",
+                "util-deprecate": "^1.0.2"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/@trivago/prettier-plugin-sort-imports": {
@@ -4639,6 +4670,20 @@
             "resolved": "https://registry.npmmirror.com/lodash/-/lodash-4.17.21.tgz",
             "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
             "devOptional": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.castarray": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmmirror.com/lodash.castarray/-/lodash.castarray-4.4.0.tgz",
+            "integrity": "sha512-aVx8ztPv7/2ULbArGJ2Y42bG1mEQ5mGjpdvrbJcJFU3TbYybe+QlLS4pst9zV52ymy2in1KpFPiZnAOATxD4+Q==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/lodash.isplainobject": {
+            "version": "4.0.6",
+            "resolved": "https://registry.npmmirror.com/lodash.isplainobject/-/lodash.isplainobject-4.0.6.tgz",
+            "integrity": "sha512-oSXzaWypCMHkPC3NvBEaPHf0KsA5mvPrOPgQWDsbg8n7orZ290M0BmC/jgRZ4vcJ6DTAhjrsSYgdsW/F+MFOBA==",
+            "dev": true,
             "license": "MIT"
         },
         "node_modules/lodash.merge": {

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "devDependencies": {
         "@egoist/tailwindcss-icons": "^1.8.1",
         "@iconify-json/mingcute": "^1.2.0",
+        "@tailwindcss/typography": "^0.5.15",
         "@trivago/prettier-plugin-sort-imports": "^4.3.0",
         "@types/react": "^18.3.10",
         "@types/react-dom": "^18.3.0",

--- a/styles/article.scss
+++ b/styles/article.scss
@@ -1,70 +1,3 @@
-#post {
-    a:not(.anchor) {
-        @apply text-blue-600 hover:underline;
-    }
-    p {
-        @apply my-2 leading-8;
-    }
-    img {
-        @apply m-auto;
-    }
-    h2 {
-        @apply my-2 text-2xl font-bold;
-    }
-    h3 {
-        @apply my-2 text-xl font-medium;
-    }
-    h4 {
-        @apply my-2 text-lg font-light;
-    }
-    ol {
-        @apply mt-3 list-decimal pl-5;
-        li {
-            @apply my-1;
-        }
-    }
-    ul {
-        @apply mt-3 list-disc pl-5;
-        li {
-            @apply my-1;
-        }
-    }
-    br {
-        content: '';
-        @apply my-2 block;
-    }
-    // 引用框
-    blockquote {
-        @apply space-y-3 rounded-r border-l-4 border-zinc-300 bg-zinc-100 p-3 dark:border-zinc-600 dark:bg-zinc-800;
-        p {
-            @apply m-0;
-        }
-    }
-    // 标题锚点
-    h2,
-    h3,
-    h4,
-    h5,
-    h6 {
-        &:has(.anchor) {
-            @apply relative flex items-center;
-        }
-        .anchor {
-            @apply absolute bottom-0 top-0 flex items-center pr-1.5 opacity-0;
-            transform: translateX(calc(-100%));
-        }
-        &:hover .anchor {
-            @apply opacity-100;
-        }
-    }
-    hr {
-        @apply mx-auto my-8 w-80 border-zinc-200 dark:border-zinc-700;
-    }
-    p > code {
-        @apply rounded bg-zinc-200 px-2 py-0.5 dark:bg-zinc-800;
-    }
-}
-
 #toc {
     position: fixed;
     top: 150px;
@@ -79,5 +12,13 @@
                 @apply font-bold opacity-70;
             }
         }
+    }
+}
+
+@layer components {
+    .post {
+        @apply prose dark:prose-invert max-w-none text-inherit;
+        @apply prose-p:leading-8 prose-img:mx-auto prose-hr:w-80 prose-hr:mx-auto;
+        @apply prose-a:no-underline hover:prose-a:underline prose-a:text-blue-600;
     }
 }

--- a/styles/article.scss
+++ b/styles/article.scss
@@ -18,7 +18,9 @@
 @layer components {
     .post {
         @apply prose dark:prose-invert max-w-none text-inherit;
-        @apply prose-p:leading-8 prose-img:mx-auto prose-hr:w-80 prose-hr:mx-auto;
-        @apply prose-a:no-underline hover:prose-a:underline prose-a:text-blue-600;
+        @apply prose-p:leading-8 prose-img:mx-auto;
+        @apply prose-a:no-underline hover:prose-a:underline prose-a:text-blue-600 prose-a:font-normal;
+        @apply prose-code:text-inherit;
+        @apply prose-hr:w-80 prose-hr:mx-auto;
     }
 }

--- a/styles/article.scss
+++ b/styles/article.scss
@@ -17,10 +17,13 @@
 
 @layer components {
     .article {
-        @apply prose max-w-none text-inherit dark:prose-invert;
+        @apply prose max-w-none dark:prose-invert;
         @apply prose-p:leading-8 prose-img:mx-auto;
+        // 超链接样式
         @apply prose-a:font-normal prose-a:text-blue-600 prose-a:no-underline hover:prose-a:underline;
-        @apply prose-code:text-inherit;
+        // 分割线样式
         @apply prose-hr:mx-auto prose-hr:w-80;
+        // 行代码样式
+        @apply prose-code:rounded prose-code:bg-zinc-200 prose-code:px-2 prose-code:py-0.5 prose-code:font-normal prose-code:before:content-none prose-code:after:content-none dark:prose-code:bg-zinc-800;
     }
 }

--- a/styles/article.scss
+++ b/styles/article.scss
@@ -16,11 +16,11 @@
 }
 
 @layer components {
-    .post {
-        @apply prose dark:prose-invert max-w-none text-inherit;
+    .article {
+        @apply prose max-w-none text-inherit dark:prose-invert;
         @apply prose-p:leading-8 prose-img:mx-auto;
-        @apply prose-a:no-underline hover:prose-a:underline prose-a:text-blue-600 prose-a:font-normal;
+        @apply prose-a:font-normal prose-a:text-blue-600 prose-a:no-underline hover:prose-a:underline;
         @apply prose-code:text-inherit;
-        @apply prose-hr:w-80 prose-hr:mx-auto;
+        @apply prose-hr:mx-auto prose-hr:w-80;
     }
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,7 +10,22 @@ module.exports = {
         './utils/**/*.{js,ts,jsx,tsx,mdx}',
     ],
     theme: {
-        extend: {},
+        extend: {
+            typography: {
+                DEFAULT: {
+                    css: {
+                        '--tw-prose-body': 'inherit',
+                        '--tw-prose-headings': 'inherit',
+                        '--tw-prose-code': 'inherit',
+                        '--tw-prose-bold': 'inherit',
+                        '--tw-prose-invert-body': 'inherit',
+                        '--tw-prose-invert-headings': 'inherit',
+                        '--tw-prose-invert-code': 'inherit',
+                        '--tw-prose-invert-bold': 'inherit',
+                    },
+                },
+            },
+        },
     },
     plugins: [
         iconsPlugin({

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 import { getIconCollections, iconsPlugin } from '@egoist/tailwindcss-icons';
+import typography from '@tailwindcss/typography';
 
 /** @type {import('tailwindcss').Config} */
 module.exports = {
@@ -15,6 +16,7 @@ module.exports = {
         iconsPlugin({
             collections: getIconCollections(['mingcute']),
         }),
+        typography(),
     ],
     darkMode: 'class',
 };

--- a/utils/data.ts
+++ b/utils/data.ts
@@ -45,6 +45,7 @@ export async function getGistsFiles() {
         },
     })
         .then(data => data.json())
-        .then(data => data.files);
+        .then(data => data.files)
+        .catch(err => console.log(err));
     return data;
 }


### PR DESCRIPTION
Use [tailwindcss-typography](https://github.com/tailwindlabs/tailwindcss-typography)

old style

![image](https://github.com/user-attachments/assets/e6c38674-6f21-4cdf-8063-b3730053eb2f)

new style

![image](https://github.com/user-attachments/assets/17d72774-6805-4470-847f-363a4dea77e8)